### PR TITLE
feat: add upsert option to MongoDB Atlas vector store node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -149,6 +149,25 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
+const updateFields: INodeProperties[] = [
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		options: [
+			{
+				displayName: 'Upsert',
+				name: 'upsert',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to perform an insert if no document with the given ID exists',
+			},
+		],
+	},
+];
+
 export const mongoConfig = {
 	client: null as MongoClient | null,
 	connectionString: '',
@@ -315,6 +334,7 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
+	updateFields,
 	sharedFields,
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
 		try {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/updateOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/updateOperation.ts
@@ -43,10 +43,19 @@ export async function handleUpdateOperation<T extends VectorStore = VectorStore>
 			extractValue: true,
 		}) as string;
 
+		const upsert = context.getNodeParameter('options.upsert', itemIndex, true) as boolean;
+
 		// Get the vector store client
 		const vectorStore = await args.getVectorStoreClient(context, undefined, embeddings, itemIndex);
 
 		try {
+			if (!upsert) {
+				const collection = (vectorStore as any).collection;
+				const primaryKey = (vectorStore as any).primaryKey ?? '_id';
+				const existing = await collection.findOne({ [primaryKey]: documentId });
+				if (!existing) continue;
+			}
+
 			// Process the document from the input
 			const { processedDocuments, serializedDocuments } = await processDocument(
 				loader,


### PR DESCRIPTION
- add Upsert toggle when updating MongoDB Atlas vector store entries
- skip updates when document missing and upsert disabled