### PR TITLE
feat: add upsert option to MongoDB Atlas vector store node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreMongoDBAtlas/VectorStoreMongoDBAtlas.node.ts
@@ -149,6 +149,25 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
+const updateFields: INodeProperties[] = [
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		options: [
+			{
+				displayName: 'Upsert',
+				name: 'upsert',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to perform an insert if no document with the given ID exists',
+			},
+		],
+	},
+];
+
 export const mongoConfig = {
 	client: null as MongoClient | null,
 	connectionString: '',
@@ -315,6 +334,7 @@ export class VectorStoreMongoDBAtlas extends createVectorStoreNode({
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
+	updateFields,
 	sharedFields,
 	async getVectorStoreClient(context, _filter, embeddings, itemIndex) {
 		try {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/updateOperation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/__tests__/updateOperation.test.ts
@@ -1,4 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+jest.mock(
+	'n8n-workflow',
+	() => ({
+		NodeOperationError: class NodeOperationError extends Error {},
+	}),
+	{ virtual: true },
+);
 import type { Document } from '@langchain/core/documents';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { VectorStore } from '@langchain/core/vectorstores';
@@ -65,11 +72,11 @@ describe('handleUpdateOperation', () => {
 		// Setup context mock
 		mockContext = mock<IExecuteFunctions>();
 		mockContext.getInputData.mockReturnValue(mockInputItems);
-		mockContext.getNodeParameter.mockImplementation((paramName, itemIndex) => {
+		mockContext.getNodeParameter.mockImplementation((paramName, itemIndex, fallback) => {
 			if (paramName === 'id') {
 				return `doc-id-${itemIndex}`;
 			}
-			return undefined;
+			return fallback;
 		});
 
 		// Setup embeddings mock
@@ -78,6 +85,7 @@ describe('handleUpdateOperation', () => {
 		// Setup vector store mock
 		mockVectorStore = mock<VectorStore>();
 		mockVectorStore.addDocuments.mockResolvedValue(undefined);
+		(mockVectorStore as any).primaryKey = '_id';
 
 		// Setup args mock
 		mockArgs = {
@@ -154,11 +162,52 @@ describe('handleUpdateOperation', () => {
 		expect(mockArgs.releaseVectorStoreClient).toHaveBeenCalledWith(mockVectorStore);
 	});
 
+	it('skips updating when document is missing and upsert disabled', async () => {
+		mockInputItems = [{ json: { text: 'only doc' } }];
+		mockContext.getInputData.mockReturnValue(mockInputItems);
+		mockContext.getNodeParameter.mockImplementation((paramName, _idx, fallback) => {
+			if (paramName === 'id') return 'missing-id';
+			if (paramName === 'options.upsert') return false;
+			return fallback;
+		});
+
+		const findOne = jest.fn().mockResolvedValue(null);
+		(mockVectorStore as any).collection = { findOne };
+
+		const result = await handleUpdateOperation(mockContext, mockArgs, mockEmbeddings);
+
+		expect(findOne).toHaveBeenCalledWith({ _id: 'missing-id' });
+		expect(mockVectorStore.addDocuments).not.toHaveBeenCalled();
+		expect(result).toHaveLength(0);
+	});
+
+	it('inserts when document is missing and upsert enabled', async () => {
+		mockInputItems = [{ json: { text: 'only doc' } }];
+		mockContext.getInputData.mockReturnValue(mockInputItems);
+		mockContext.getNodeParameter.mockImplementation((paramName, _index, fallback) => {
+			if (paramName === 'id') return 'missing-id';
+			if (paramName === 'options.upsert') return true;
+			return fallback;
+		});
+
+		const findOne = jest.fn();
+		(mockVectorStore as any).collection = { findOne };
+
+		const result = await handleUpdateOperation(mockContext, mockArgs, mockEmbeddings);
+
+		expect(findOne).not.toHaveBeenCalled();
+		expect(mockVectorStore.addDocuments).toHaveBeenCalledTimes(1);
+		expect(result).toHaveLength(1);
+	});
+
 	it('should use proper document ID from node parameters', async () => {
 		// Setup custom document IDs
-		mockContext.getNodeParameter
-			.mockReturnValueOnce('custom-id-123')
-			.mockReturnValueOnce('custom-id-456');
+		mockContext.getNodeParameter.mockImplementation((paramName, itemIndex, fallback) => {
+			if (paramName === 'id') {
+				return itemIndex === 0 ? 'custom-id-123' : 'custom-id-456';
+			}
+			return fallback;
+		});
 
 		await handleUpdateOperation(mockContext, mockArgs, mockEmbeddings);
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/updateOperation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode/operations/updateOperation.ts
@@ -43,10 +43,19 @@ export async function handleUpdateOperation<T extends VectorStore = VectorStore>
 			extractValue: true,
 		}) as string;
 
+		const upsert = context.getNodeParameter('options.upsert', itemIndex, true) as boolean;
+
 		// Get the vector store client
 		const vectorStore = await args.getVectorStoreClient(context, undefined, embeddings, itemIndex);
 
 		try {
+			if (!upsert) {
+				const collection = (vectorStore as any).collection;
+				const primaryKey = (vectorStore as any).primaryKey ?? '_id';
+				const existing = await collection.findOne({ [primaryKey]: documentId });
+				if (!existing) continue;
+			}
+
 			// Process the document from the input
 			const { processedDocuments, serializedDocuments } = await processDocument(
 				loader,


### PR DESCRIPTION
## Summary
- add Upsert toggle when updating MongoDB Atlas vector store entries
- skip updates when document missing and upsert disabled
- test update operation upsert behavior